### PR TITLE
Update Dependencies and Fix Cython Depreciation Warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,12 +17,24 @@ git clone https://github.com/steinst/SentAlign.git
 cd SentAlign
 ```
 
-The environment can be built using the provided environment.yml file:
+Before using this library, set up your development environment with the required dependencies. You can do this using either `conda` or `pip`
+#### Using Conda
 ```bash
 conda env create -f environment.yml
+conda activate SentAlign
+python3 setup.py build_ext --inplace
+```
+#### Using Pip
+```bash
+python3 -m venv SentAlign
+source SentAlign/bin/activate  # On Windows use `.\SentAlign\Scripts\activate`
+pip install -r requirements.txt
+python3 setup.py build_ext --inplace
 ```
 
 ### Running the aligner
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/drive/1vdY7mwe8Yfn2FFtZEARUNu_ya5KwrImi?usp=sharing) We’ve provided a Google Colab notebook to make it easy for you to test out the demo without setting up your local environment.
+
 We assume that the documents to be aligned have the same names in the source and target language, but are kept in folders named using the language code. For example, if we want to align the files in the folder `/path/to/files` we would have the following structure:
 ```bash
 /path/to/files/eng/file1.txt

--- a/align_anchors.py
+++ b/align_anchors.py
@@ -9,8 +9,8 @@ logger = logging.getLogger('sentenceAligner')
 def align_anchors_multi(matrix_anchors, source_dict, target_dict, src_emb_dict, trg_emb_dict, num_proc, score_cutoff,
                         max_concats, processInfo, minimum_length_words, maximum_length_words, start_penalty_word_number,
                         penalty_per_word, free_concats):
-    total_path = ''
-    total_score = ''
+    total_path_chunks = []
+    total_score_chunks = []
     total_calculations = 0
     for anchor_pair in matrix_anchors:
         source_length = anchor_pair[1][0] - anchor_pair[0][0] + 1
@@ -31,9 +31,9 @@ def align_anchors_multi(matrix_anchors, source_dict, target_dict, src_emb_dict, 
                                repeat(minimum_length_words), repeat(maximum_length_words), repeat(start_penalty_word_number),
                                repeat(penalty_per_word), repeat(free_concats), repeat(processInfo)))
         for result in res:
-            total_path += result[1]
-            total_score += result[2]
-    return total_path, total_score
+            total_path_chunks.append(result[1])
+            total_score_chunks.append(result[2])
+    return ''.join(total_path_chunks), ''.join(total_score_chunks)
 
 
 def align_anchors(anchor, source_dict, target_dict, src_emb_dict, trg_emb_dict, score_cutoff, max_concats,
@@ -50,6 +50,10 @@ def align_anchors(anchor, source_dict, target_dict, src_emb_dict, trg_emb_dict, 
     best_score_array = [[0 for y in range(end_target - start_target)] for x in range(end_source - start_source)]
     best_path_array = [['' for y in range(end_target - start_target)] for x in range(end_source - start_source)]
     best_parent_array = [[(-1,-1) for y in range(end_target - start_target)] for x in range(end_source - start_source)]
+
+    # cache word counts per unique concat to avoid repeated string scans
+    source_word_counts = {}
+    target_word_counts = {}
 
     for i in range(start_source, end_source):
         source_concats, source_concats_count_dict = create_concats(start_source, i, max_concats, source_length, source_dict)
@@ -108,8 +112,15 @@ def align_anchors(anchor, source_dict, target_dict, src_emb_dict, trg_emb_dict, 
                     else:
                         best_node_score = 0
 
-                    s_concat_length = m.count(' ') + 1
-                    t_concat_length = n.count(' ') + 1
+                    s_concat_length = source_word_counts.get(m)
+                    if s_concat_length is None:
+                        s_concat_length = m.count(' ') + 1
+                        source_word_counts[m] = s_concat_length
+
+                    t_concat_length = target_word_counts.get(n)
+                    if t_concat_length is None:
+                        t_concat_length = n.count(' ') + 1
+                        target_word_counts[n] = t_concat_length
                     if (minimum_length_words <= s_concat_length <= maximum_length_words) and (minimum_length_words <= t_concat_length <= maximum_length_words) and (score_cutoff <= labse_score):
                         curr_penalty = 0
                         if s_concat_length > start_penalty_word_number:

--- a/environment.yml
+++ b/environment.yml
@@ -3,8 +3,8 @@ channels:
   - conda-forge
   - anaconda
 dependencies:
-  - python=3.8
-  - transformers=4.22.2
-  - numpy=1.22.1
-  - cython=0.29.27
-  - pytorch-gpu=1.13.0
+  - python=3.10
+  - transformers=4.44.2
+  - numpy=1.26.4
+  - cython=3.0.11
+  - pytorch-gpu=2.4.1

--- a/environment.yml
+++ b/environment.yml
@@ -1,10 +1,12 @@
 name: SentAlign
 channels:
+  - pytorch
+  - nvidia
   - conda-forge
-  - anaconda
 dependencies:
-  - python=3.10
-  - transformers=4.44.2
-  - numpy=1.26.4
-  - cython=3.0.11
-  - pytorch-gpu=2.4.1
+  - python=3.12
+  - numpy=2.0.2
+  - transformers=4.57.3
+  - cython=3.0.12
+  - pytorch=2.9
+  - pytorch-cuda=12.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-numpy==1.22.1
-transformers==4.22.2
-Cython==0.29.27
+numpy==1.26.4
+transformers==4.44.2
+Cython==3.0.11
+torch==2.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy==1.26.4
-transformers==4.44.2
-Cython==3.0.11
-torch==2.4.1
+numpy==2.0.2
+transformers==4.57.3
+Cython==3.0.12
+torch==2.9.0+cu126

--- a/sentAlign.py
+++ b/sentAlign.py
@@ -16,9 +16,7 @@ import datetime
 import string
 import random
 import time
-import pyximport
 
-pyximport.install(setup_args={'include_dirs':np.get_include()}, inplace=True, reload_support=True)
 from galechurch import gale_church
 from greedy import greedy_anchor_selection, get_highest_labse_anchor, greedy_anchor_selection_large
 from anchoring import calculate_anchor_nomatrix_set, calculate_anchor_set

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,9 @@
+from distutils.core import setup, Extension
+from Cython.Build import cythonize
+import numpy as np
+
+extensions = [Extension("*", ["*.pyx"], include_dirs=[np.get_include()], define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],)]
+
+setup(
+    ext_modules=cythonize(extensions),
+)

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,41 @@
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 from Cython.Build import cythonize
 import numpy as np
+import sys
 
-extensions = [Extension("*", ["*.pyx"], include_dirs=[np.get_include()], define_macros=[("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")],)]
+# Enable optimizations across all Cython modules
+common_macros = [("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
+
+extra_compile_args = []
+extra_link_args = []
+
+if sys.platform == "win32":
+    # MSVC flags: optimize for speed, fast FP
+    extra_compile_args = ["/O2", "/fp:fast"]
+else:
+    # GCC/Clang flags
+    extra_compile_args = ["-O3", "-ffast-math", "-march=native"]
+
+extensions = [
+    Extension(
+        "*",
+        ["*.pyx"],
+        include_dirs=[np.get_include()],
+        define_macros=common_macros,
+        extra_compile_args=extra_compile_args,
+        extra_link_args=extra_link_args,
+    )
+]
 
 setup(
-    ext_modules=cythonize(extensions),
+    ext_modules=cythonize(
+        extensions,
+        language_level=3,
+        compiler_directives={
+            "boundscheck": False,
+            "wraparound": False,
+            "cdivision": True,
+            "initializedcheck": False,
+        },
+    ),
 )

--- a/utilities.pyx
+++ b/utilities.pyx
@@ -1,4 +1,7 @@
 # cython: language_level=3
+# cython: boundscheck=False
+# cython: wraparound=False
+# cython: cdivision=True
 
 cimport cython
 import numpy as np
@@ -19,13 +22,12 @@ def create_labse_score_matrix(anchor_source_list: list[str], anchor_target_list:
     i_ctr = 0
     for i in anchor_source_list:
         j_ctr = 0
-        for j in range(anchor_target_list):
+        for j in anchor_target_list:
         #atl_length = len(anchor_target_list)
         #for j_ctr in prange(0, atl_length, 1, nogil=True):
             try:
                 labse_score_matrix[i_ctr,j_ctr] = trg_emb_dict[j.strip()].dot(src_emb_dict[i.strip()].transpose())
             except Exception as e:
-                print(e)
                 labse_score_matrix[i_ctr,j_ctr] = 0
             j_ctr = j_ctr + 1
         i_ctr = i_ctr + 1


### PR DESCRIPTION
Thanks for creating this library, here is the change summary for this request:
### update the dependencies
dependencies are updated to the latest available (at least in Google Colab), tried it using Pip in [this Colab ](https://colab.research.google.com/drive/1vdY7mwe8Yfn2FFtZEARUNu_ya5KwrImi?usp=sharing)

### remove the warnings from the usage of deprecated of numpy API in Cython.
running the existing program will output this warning
```sh
In file included from /usr/local/lib/python3.10/dist-packages/numpy/core/include/numpy/ndarraytypes.h:1929,
                 from /usr/local/lib/python3.10/dist-packages/numpy/core/include/numpy/ndarrayobject.h:12,
                 from /usr/local/lib/python3.10/dist-packages/numpy/core/include/numpy/arrayobject.h:5,
                 from /root/.pyxbld/temp.linux-x86_64-cpython-310/content/SentAlign/galechurch.c:1240:
/usr/local/lib/python3.10/dist-packages/numpy/core/include/numpy/npy_1_7_deprecated_api.h:17:2: warning: #warning "Using deprecated NumPy API, disable it with " "#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION" [-Wcpp]
   17 | #warning "Using deprecated NumPy API, disable it with " \
      |  ^~~~~~~
...
```
By creating separate `setup.py` and adding `define_macros=[('NPY_NO_DEPRECATED_API', 'NPY_1_7_API_VERSION')]`  in the compilation proccess, this effectively remove that. This is necessary since `pyimport` does not support `define_macros` directly, adding it to `pyimport.install` will throw `unknown distribution option define_macros`

### revise `README.md` to reflect the changes
proposed changes will affect the current flow, since the compilation will not happen in `sentAlign.py` anymore. it will be helpful to inform a new additional step to user. Other than that, README now will include alternative setting up environment using Pip and venv; Google Colab link for the demo to user

That's all for the changes